### PR TITLE
🏮Оптимизация работы с образом🏮

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,10 +7,12 @@ RUN python3 -m pip install -U platformio==${PLATFORMIO_VERSION}
 WORKDIR /opt
 
 COPY ./include/ /opt/include/
-COPY ./lib/ /opt/lib/
-COPY ./src/ /opt/src/
 COPY ./test/ /opt/test/
+COPY ./lib/ /opt/lib/
 COPY ./CMakeLists.txt ./platformio.ini /opt/
+COPY ./src/ /opt/src/
+
+RUN platformio pkg install
 
 ENTRYPOINT ["platformio"]
 


### PR DESCRIPTION
## Что сделал

В `Dockerfile` прописал установку необходимых библиотек. При работе с контейнером (`platfirmio run`) нужны установленные зависимости, и если их нет то они загружаются
Чтобы не заставлять клиента _(использующего этот образ)_ каждый раз скачивать зависимости предустановил их на этапе сборки